### PR TITLE
Add a ‘needs improvement’ threshold for core web vitals; improve icons.

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -38,15 +38,20 @@
   content: '🕐';
 }
 
-.web-vitals div.is-great dd::after {
+.web-vitals div.is-good dd::after {
   content: '✅';
 }
 
+.web-vitals div.needs-improvement dd::after {
+  content: '⚠️';
+}
+
 .web-vitals div.is-poor dd::after {
-  content: '😿';
+  content: '❌';
 }
 
 .web-vitals dd {
   text-align: right;
   margin-left: 1em;
 }
+

--- a/src/web-vitals.js
+++ b/src/web-vitals.js
@@ -8,8 +8,10 @@ const METRIC_CONFIG = new Map([
   [
     'CLS',
     {
-      goodThreshold: 0.1,
-      needsImprovementThreshold: 0.25,
+      thresholds: {
+        good: 0.1,
+        needsImprovement: 0.25,
+      },
       observerEntryType: 'layout-shift',
       explainerURL: 'https://web.dev/cls/',
     },
@@ -17,7 +19,9 @@ const METRIC_CONFIG = new Map([
   [
     'FCP',
     {
-      goodThreshold: 2500,
+      thresholds: {
+        good: 2500,
+      },
       observerEntryType: 'paint',
       explainerURL: 'https://web.dev/fcp/',
       unit: MS_UNIT,
@@ -26,8 +30,10 @@ const METRIC_CONFIG = new Map([
   [
     'FID',
     {
-      goodThreshold: 100,
-      needsImprovementThreshold: 300,
+      thresholds: {
+        good: 100,
+        needsImprovement: 300,
+      },
       observerEntryType: 'first-input',
       explainerURL: 'https://web.dev/fid/',
       unit: MS_UNIT,
@@ -36,8 +42,10 @@ const METRIC_CONFIG = new Map([
   [
     'LCP',
     {
-      goodThreshold: 2500,
-      needsImprovementThreshold: 4000,
+      thresholds: {
+        good: 2500,
+        needsImprovement: 4000,
+      },
       observerEntryType: 'paint',
       explainerURL: 'https://web.dev/lcp/',
       unit: MS_UNIT,
@@ -46,7 +54,9 @@ const METRIC_CONFIG = new Map([
   [
     'TTFB',
     {
-      goodThreshold: 2500,
+      thresholds: {
+        good: 2500,
+      },
       explainerURL: 'https://web.dev/time-to-first-byte/',
       unit: MS_UNIT,
     },
@@ -141,16 +151,17 @@ class WebVitals extends HTMLElement {
       <dl>
         ${[...this.metrics]
           .map(([key, metric]) => {
-            const { explainerURL, isFinal, goodThreshold, needsImprovementThreshold, unit, value } = metric;
+            const { explainerURL, isFinal, thresholds, unit, value } = metric;
             let classes = '';
+            const { good, needsImprovement } = thresholds;
 
             if (isFinal) {
               classes += 'is-final ';
               let score = 'is-poor';
-              if ( needsImprovementThreshold && value <= needsImprovementThreshold ) {
+              if ( needsImprovement && value <= needsImprovement ) {
                 score = 'needs-improvement';
               }
-              if ( value <= goodThreshold ) {
+              if ( value <= good ) {
                 score = 'is-good';
               }
               classes += score;

--- a/src/web-vitals.js
+++ b/src/web-vitals.js
@@ -8,7 +8,8 @@ const METRIC_CONFIG = new Map([
   [
     'CLS',
     {
-      threshold: 0.1,
+      goodThreshold: 0.1,
+      needsImprovementThreshold: 0.25,
       observerEntryType: 'layout-shift',
       explainerURL: 'https://web.dev/cls/',
     },
@@ -16,7 +17,7 @@ const METRIC_CONFIG = new Map([
   [
     'FCP',
     {
-      threshold: 2500,
+      goodThreshold: 2500,
       observerEntryType: 'paint',
       explainerURL: 'https://web.dev/fcp/',
       unit: MS_UNIT,
@@ -25,7 +26,8 @@ const METRIC_CONFIG = new Map([
   [
     'FID',
     {
-      threshold: 100,
+      goodThreshold: 100,
+      needsImprovementThreshold: 300,
       observerEntryType: 'first-input',
       explainerURL: 'https://web.dev/fid/',
       unit: MS_UNIT,
@@ -34,7 +36,8 @@ const METRIC_CONFIG = new Map([
   [
     'LCP',
     {
-      threshold: 2500,
+      goodThreshold: 2500,
+      needsImprovementThreshold: 4000,
       observerEntryType: 'paint',
       explainerURL: 'https://web.dev/lcp/',
       unit: MS_UNIT,
@@ -43,7 +46,7 @@ const METRIC_CONFIG = new Map([
   [
     'TTFB',
     {
-      threshold: 2500,
+      goodThreshold: 2500,
       explainerURL: 'https://web.dev/time-to-first-byte/',
       unit: MS_UNIT,
     },
@@ -138,12 +141,19 @@ class WebVitals extends HTMLElement {
       <dl>
         ${[...this.metrics]
           .map(([key, metric]) => {
-            const { explainerURL, isFinal, threshold, unit, value } = metric;
+            const { explainerURL, isFinal, goodThreshold, needsImprovementThreshold, unit, value } = metric;
             let classes = '';
 
             if (isFinal) {
               classes += 'is-final ';
-              classes += value > threshold ? 'is-poor' : 'is-great';
+              let score = 'is-poor';
+              if ( needsImprovementThreshold && value < needsImprovementThreshold ) {
+                score = 'needs-improvement';
+              }
+              if ( value < goodThreshold ) {
+                score = 'is-good';
+              }
+              classes += score;
             }
 
             return `

--- a/src/web-vitals.js
+++ b/src/web-vitals.js
@@ -147,10 +147,10 @@ class WebVitals extends HTMLElement {
             if (isFinal) {
               classes += 'is-final ';
               let score = 'is-poor';
-              if ( needsImprovementThreshold && value < needsImprovementThreshold ) {
+              if ( needsImprovementThreshold && value <= needsImprovementThreshold ) {
                 score = 'needs-improvement';
               }
-              if ( value < goodThreshold ) {
+              if ( value <= goodThreshold ) {
                 score = 'is-good';
               }
               classes += score;


### PR DESCRIPTION
Core web vitals CLS, FID and LCP define both a "good" threshold and a "needs improvement" threshold (see [web.dev](https://web.dev/vitals/#core-web-vitals)). This PR seeks to recognize those thresholds and display a 'warning' icon when a metric needs improvement. 

I left the green checkmark for good, added a yellow warning for needs improvement and changed the is-poor icon to a red X.

Looks something like this:

![image](https://user-images.githubusercontent.com/2676022/91605787-3e3a5880-e92e-11ea-97a4-7f654eb862ce.png)
